### PR TITLE
Added missing header for std::strcmp and GCDecompiler recompile not bring recognised

### DIFF
--- a/GCDecompiler/rel_reader.cpp
+++ b/GCDecompiler/rel_reader.cpp
@@ -365,7 +365,7 @@ int main(int argc, char *argv[]) {
 			std::cout << "Dumping REL" << endl;
 			rel.dump_all(output);
 			std::cout << "REL dump complete" << endl;
-		} else if (!std::strcmp(argv[0], "recompile")) {
+		} else if (!std::strcmp(argv[1], "recompile")) {
 			std::cout << "Recompiling REL" << endl;
 			rel.compile(output);
 			std::cout << "REL recompile complete" << endl;

--- a/GCDecompiler/rel_reader.cpp
+++ b/GCDecompiler/rel_reader.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <iomanip>
 #include <iostream>
+#include <cstring>
 #include "rel_reader.h"
 #include "types.h"
 


### PR DESCRIPTION
Without the `cstring` header, clang complained about `error: no member named 'strcmp' in namespace 'std'`