### PR TITLE
Added missing cmath header and added the Unix way of creating a directory

### DIFF
--- a/GCDecompiler/ppc_reader.cpp
+++ b/GCDecompiler/ppc_reader.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <iostream>
 #include <iomanip>
+#include <cmath>
 #include "types.h"
 #include "utils.h"
 

--- a/GCDecompiler/rel_reader.cpp
+++ b/GCDecompiler/rel_reader.cpp
@@ -7,7 +7,13 @@
 #include <sstream>
 #include <iomanip>
 #include <iostream>
+
+#if defined(_WIN32) || defined(WIN32)
 #include <Windows.h>
+#else
+#include <sys/stat.h>
+#endif
+
 #include "utils.h"
 #include <cstring>
 #include "rel_reader.h"
@@ -348,14 +354,20 @@ int main(int argc, char *argv[]) {
 		REL rel(argv[2]);
 		if (!std::strcmp(argv[1], "dump")) {
 			const char *path = output.c_str();
-			//CreateDirectory(path, nullptr);
-			rel.dump_header(output + "\\header.txt");
-			rel.dump_sections(output + "\\sections.txt");
-			rel.dump_imports(output + "\\imports.txt");
+
+			#if defined(_WIN32) || defined(WIN32)
+			CreateDirectory(path, nullptr);
+			#else
+			mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+			#endif
+
+			rel.dump_header(output + "/header.txt");
+			rel.dump_sections(output + "/sections.txt");
+			rel.dump_imports(output + "/imports.txt");
 			for (vector<Section>::iterator sect = rel.sections.begin(); sect != rel.sections.end(); sect++) {
 				if (sect->exec && sect->offset) {
 					std::stringstream name;
-					name << output << "\\Section" << sect->id << ".ppc";
+					name << output << "/Section" << sect->id << ".ppc";
 					PPC::decompile(argv[2], name.str(), sect->offset, sect->offset + sect->length);
 				}
 			}


### PR DESCRIPTION
- The `cmath` header was missing in `ppc_reader.cpp`, leaving functions such as `floor` and `pow` undefined

- This refused to build on OSs other than Windows due to the `Windows.h` dependency.
    - I noticed you only used `CreateDirectory` from `Windows.h`, so it was an easy fix
    - I wrapped the `#include` around an `#if defined(_WIN32) || defined(WIN32)`, and put the appropriate Unix header in the `else` clause
    - I uncommented `CreateDirectory` and wrapped it around another `#if defined ...`
    - And I also replaced the `\\` path separators with `/` to prevent unsightly filenames with backslashes (Windows should still accept `/` as a path separator)